### PR TITLE
Bugfix : field wich name end with [] musn't be take in count in the dotted notation

### DIFF
--- a/classes/fieldset.php
+++ b/classes/fieldset.php
@@ -531,13 +531,9 @@ class Fieldset
 		{
 			if (is_array($input) or $input instanceof \ArrayAccess)
 			{
-				// remove the last array to prevent it to be converted in the dotted notation
-				$name = $f->name;
-				if (\Str::ends_with($name, '[]')) {
-					$name = \Str::sub($name, 0, \Str::length($name)-2);
-				}
 				// convert form field array's to Fuel dotted notation
-				$name = str_replace(array('[',']'), array('.', ''), $name);
+				// remove the last point to prevent accessing a null index
+				$name = trim(str_replace(array('[',']'), array('.', ''), $f->name), '.');
 
 				// fetch the value for this field, and set it if found
 				$value = \Arr::get($input, $name, null);

--- a/classes/fieldset.php
+++ b/classes/fieldset.php
@@ -532,7 +532,7 @@ class Fieldset
 			if (is_array($input) or $input instanceof \ArrayAccess)
 			{
 				// convert form field array's to Fuel dotted notation
-				// remove the last point to prevent accessing a null index
+				// remove trailing dot to prevent accessing a null index
 				$name = trim(str_replace(array('[',']'), array('.', ''), $f->name), '.');
 
 				// fetch the value for this field, and set it if found

--- a/classes/fieldset.php
+++ b/classes/fieldset.php
@@ -531,8 +531,13 @@ class Fieldset
 		{
 			if (is_array($input) or $input instanceof \ArrayAccess)
 			{
+				// remove the last array to prevent it to be converted in the dotted notation
+				$name = $f->name;
+				if (\Str::ends_with($name, '[]')) {
+					$name = \Str::sub($name, 0, \Str::length($name)-2);
+				}
 				// convert form field array's to Fuel dotted notation
-				$name = str_replace(array('[',']'), array('.', ''), $f->name);
+				$name = str_replace(array('[',']'), array('.', ''), $name);
 
 				// fetch the value for this field, and set it if found
 				$value = \Arr::get($input, $name, null);


### PR DESCRIPTION
If this isn't done, `$name` will be `'field_name.'` and the value will not be find by the `Arr` class
