### PR TITLE
Fix creation of multiple sub-directories with File::create_dir

### DIFF
--- a/classes/file.php
+++ b/classes/file.php
@@ -143,45 +143,49 @@ class File
 	 */
 	public static function create_dir($basepath, $name, $chmod = null, $area = null)
 	{
-		$basepath	= rtrim(static::instance($area)->get_path($basepath), '\\/').DS;
-		$new_dir	= static::instance($area)->get_path($basepath.trim($name,'\\/'));
+		$path	 = rtrim(static::instance($area)->get_path($basepath), '\\/').DS;
+		$new_dir = static::instance($area)->get_path($path.trim($name, '\\/'));
 		is_null($chmod) and $chmod = \Config::get('file.chmod.folders', 0777);
-
-		if ( ! is_dir($basepath) or ! is_writable($basepath))
+		if ( ! is_dir($path) or ! is_writable($path))
 		{
-			throw new \InvalidPathException('Invalid basepath: "'.$basepath.'", cannot create directory at this location.');
+			throw new \InvalidPathException('Invalid basepath: "'.$path.'", cannot create directory at this location.');
 		}
 		elseif (is_dir($new_dir))
 		{
 			throw new \FileAccessException('Directory: "'.$new_dir.'" exists already, cannot be created.');
 		}
-
 		// unify the path separators, and get the part we need to add to the basepath
-		$new_dir = substr(str_replace(array('\\', '/'), DS, $new_dir), strpos($new_dir, $name));
-
+		$segments = explode(DS, str_replace(array('\\', '/'), DS, substr($new_dir, strlen($path))));
 		// recursively create the directory. we can't use mkdir permissions or recursive
 		// due to the fact that mkdir is restricted by the current users umask
-		$basepath = rtrim($basepath, DS);
-		foreach (explode(DS, $new_dir) as $dir)
+		foreach ($segments as $dir)
 		{
-			$basepath .= DS.$dir;
-			if ( ! is_dir($basepath))
+			// some security checking
+			if ($dir == '.' or $dir == '..')
+			{
+				throw new \FileAccessException('Directory to be created contains illegal segments.');
+			}
+			$path .= DS.$dir;
+			if ( ! is_dir($path))
 			{
 				try
 				{
-					if ( ! mkdir($basepath))
+					if ( ! mkdir($path))
 					{
 						return false;
 					}
-					chmod($basepath, $chmod);
+					chmod($path, $chmod);
 				}
 				catch (\PHPErrorException $e)
 				{
-					return false;
+					if ( ! is_dir($path))
+					{
+						return false;
+					}
+					chmod($path, $chmod);
 				}
 			}
 		}
-
 		return true;
 	}
 


### PR DESCRIPTION
The `File::create_dir` method fails when there is more than one sub-directory to create.

For example `File::create_dir('/tmp/', 'folder/subfolder');` will create `/tmp/folder` but not `/tmp/folder/subfolder`.

The code of this PR is a copy/paste of the current code of the `1.9/develop` branch where the bug (among others) was fixed : https://github.com/fuel/core/commit/0b9f79764d46d19664a90136a9b46930624479be
